### PR TITLE
Remove sample from cost endpoint calls.

### DIFF
--- a/src/herbie/HerbieUI.tsx
+++ b/src/herbie/HerbieUI.tsx
@@ -241,7 +241,7 @@ function HerbieUIInner() {
           // console.log("Expression is " + formula);
           // console.log("sample is " + sample);
 
-          const costData = await herbiejs.getCost(formula, sample, serverUrl);
+          const costData = await herbiejs.getCost(formula, serverUrl);
 
           console.log("hooray the cost data is: ", costData);
 

--- a/src/herbie/lib/herbiejs.ts
+++ b/src/herbie/lib/herbiejs.ts
@@ -188,10 +188,9 @@ export const analyzeErrorExpression = async (
 
 export const getCost = async (
   fpcore: string,
-  sample: Sample,
   host: string
 ): Promise<number> => {
-  return (await getHerbieApi(host, 'cost', { formula: fpcore, sample: sample.points }, true) as CostResponse).cost;
+  return (await getHerbieApi(host, 'cost', { formula: fpcore }, true) as CostResponse).cost;
 };
 
 type point = ordinal[]


### PR DESCRIPTION
The `cost` endpoint in Herbie doesn't take in a sample. This may be a bug on Herbie but this avoids sending unnecessary JSON.

[Herbie cost](https://github.com/herbie-fp/herbie/blob/1a83c9f5186db102b678a2d5f869f99992469071/src/api/sandbox.rkt#L288)